### PR TITLE
Support `host` alias for `hostname`

### DIFF
--- a/lib/Agent.js
+++ b/lib/Agent.js
@@ -23,7 +23,7 @@ function createConnection(options) {
 	handleSocksConnectToHost = socksSocket.handleSocksConnectToHost;
 	socksSocket.handleSocksConnectToHost = function() {
 		options.socket = socksSocket.socket;
-		options.servername = options.hostname;
+		options.servername = options.hostname || options.host;
 
 		socksSocket.socket = tls.connect(options, function() {
 


### PR DESCRIPTION
Looks like latest `request` sends `options.host` instead of `options.hostname` and this breaks this module, resulting in a socket hang up error:

```
stream.js:74
      throw er; // Unhandled stream error in pipe.
      ^

Error: socket hang up
    at TLSSocket.onHangUp (_tls_wrap.js:1049:19)
    at TLSSocket.g (events.js:260:16)
    at emitNone (events.js:72:20)
    at TLSSocket.emit (events.js:166:7)
    at endReadableNT (_stream_readable.js:913:12)
    at nextTickCallbackWith2Args (node.js:442:9)
    at process._tickDomainCallback (node.js:397:17)
```